### PR TITLE
Add CD rollback + non-root Dockerfile examples

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -87,13 +87,28 @@ jobs:
           username: ${{ secrets.VPS_USER }}
           key: ${{ secrets.VPS_SSH_KEY }}
           script: |
+            set -e
             IMAGE="ghcr.io/${{ github.repository }}:${{ steps.version.outputs.version }}"
             PORT="${{ secrets.APP_PORT || '3000' }}"
             mkdir -p ~/app
-            cat > ~/app/docker-compose.yml << EOF
+            cd ~/app
+
+            # Capture currently running image for potential rollback
+            PREV_IMAGE=""
+            if docker compose ps -q app >/dev/null 2>&1; then
+              CID=$(docker compose ps -q app || true)
+              if [ -n "$CID" ]; then
+                PREV_IMAGE=$(docker inspect --format '{{.Config.Image}}' "$CID" 2>/dev/null || true)
+              fi
+            fi
+            echo "Previous image: ${PREV_IMAGE:-<none>}"
+
+            write_compose() {
+              local img="$1"
+              cat > ~/app/docker-compose.yml << EOF
             services:
               app:
-                image: $IMAGE
+                image: $img
                 env_file: $HOME/.env.app
                 ports:
                   - "${PORT}:${PORT}"
@@ -105,10 +120,25 @@ jobs:
                   retries: 3
                   start_period: 10s
             EOF
-            cd ~/app
+            }
+
+            write_compose "$IMAGE"
             docker compose pull
-            docker compose up -d --wait
-            docker image prune -f
+
+            if docker compose up -d --wait; then
+              echo "Deploy succeeded."
+              docker image prune -f
+            else
+              echo "::error::Deploy health check failed."
+              if [ -n "$PREV_IMAGE" ] && [ "$PREV_IMAGE" != "$IMAGE" ]; then
+                echo "Rolling back to $PREV_IMAGE"
+                write_compose "$PREV_IMAGE"
+                docker compose up -d --wait || echo "::error::Rollback also failed — manual intervention required."
+              else
+                echo "No previous image available to roll back to."
+              fi
+              exit 1
+            fi
 
       - name: Clean up old GHCR images
         uses: actions/delete-package-versions@v5

--- a/docs/DOCKERFILE_EXAMPLES.md
+++ b/docs/DOCKERFILE_EXAMPLES.md
@@ -33,9 +33,12 @@ COPY app/ .
 
 FROM python:3.12-slim
 
+RUN adduser --disabled-password --gecos "" app
 WORKDIR /app
 COPY --from=build /usr/local/lib/python3.12/site-packages /usr/local/lib/python3.12/site-packages
-COPY --from=build /app .
+COPY --from=build --chown=app:app /app .
+
+USER app
 
 EXPOSE 8000
 CMD ["python", "-m", "uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]
@@ -54,8 +57,11 @@ RUN CGO_ENABLED=0 go build -o server .
 
 FROM alpine:3.20
 
+RUN adduser -D -H app
 WORKDIR /app
-COPY --from=build /app/server .
+COPY --from=build --chown=app:app /app/server .
+
+USER app
 
 EXPOSE 8080
 CMD ["./server"]
@@ -74,8 +80,11 @@ RUN cargo build --release
 
 FROM alpine:3.20
 
+RUN adduser -D -H app
 WORKDIR /app
-COPY --from=build /app/target/release/server .
+COPY --from=build --chown=app:app /app/target/release/server .
+
+USER app
 
 EXPOSE 8080
 CMD ["./server"]
@@ -92,8 +101,11 @@ RUN ./gradlew bootJar --no-daemon
 
 FROM eclipse-temurin:21-jre-alpine
 
+RUN addgroup --system app && adduser --system --ingroup app app
 WORKDIR /app
-COPY --from=build /app/build/libs/*.jar app.jar
+COPY --from=build --chown=app:app /app/build/libs/*.jar app.jar
+
+USER app
 
 EXPOSE 8080
 CMD ["java", "-jar", "app.jar"]
@@ -109,6 +121,8 @@ COPY app/ /usr/share/nginx/html
 EXPOSE 80
 CMD ["nginx", "-g", "daemon off;"]
 ```
+
+> Note: The official `nginx:alpine` image runs as root by default to bind port 80. For non-root Nginx, use `nginxinc/nginx-unprivileged:alpine` (listens on 8080).
 
 ## Tips
 


### PR DESCRIPTION
## Summary

Two hardening improvements for the deploy pipeline and example Dockerfiles.

### CD rollback (`.github/workflows/cd.yml`)
- Captures the currently running image tag on the VPS *before* the new deploy.
- If `docker compose up -d --wait` fails the health check, rewrites the compose file with the previous tag and restarts.
- Result: failed deploys self-recover to the last known-good image instead of leaving the service down.

### Non-root USER in examples (`docs/DOCKERFILE_EXAMPLES.md`)
- Adds a non-root `USER app` directive to the Python, Go, Rust, and Java examples, matching the existing Node example's `USER node` pattern.
- 4 languages now ship secure-by-default examples.

## Test plan

- [ ] Lint (hadolint) passes on updated Dockerfile examples.
- [ ] YAML lint passes on `cd.yml`.
- [ ] Manual read-through of rollback logic.