### PR TITLE
docs: add create-starter as primary Quick Start option

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -25,6 +25,25 @@
 
 ## 빠른 시작
 
+**[create-starter](https://github.com/starter-series/create-starter) 사용** (권장):
+
+```bash
+npx @starter-series/create my-service --template docker-deploy
+cd my-service
+# 내 앱 Dockerfile + 코드 추가 후:
+docker compose up
+```
+
+**또는 직접 clone:**
+
+```bash
+git clone https://github.com/starter-series/docker-deploy-starter my-service
+cd my-service
+docker compose up
+```
+
+**전체 셋업 (내 앱 가져오기):**
+
 ```bash
 # 1. GitHub에서 "Use this template" 클릭 (또는 clone)
 git clone https://github.com/starter-series/docker-deploy-starter.git my-app

--- a/README.md
+++ b/README.md
@@ -25,6 +25,25 @@ Build your app. Push to deploy.
 
 ## Quick Start
 
+**Via [create-starter](https://github.com/starter-series/create-starter)** (recommended):
+
+```bash
+npx @starter-series/create my-service --template docker-deploy
+cd my-service
+# Add your app's Dockerfile + code, then:
+docker compose up
+```
+
+**Or clone directly:**
+
+```bash
+git clone https://github.com/starter-series/docker-deploy-starter my-service
+cd my-service
+docker compose up
+```
+
+**Full setup (bring your own app):**
+
 ```bash
 # 1. Click "Use this template" on GitHub (or clone)
 git clone https://github.com/starter-series/docker-deploy-starter.git my-app


### PR DESCRIPTION
## Summary
- Promote `npx @starter-series/create my-service --template docker-deploy` as the first/recommended Quick Start path.
- Keep direct `git clone` as a fallback and retain the existing bring-your-own-app walkthrough for language swaps.
- Mirror in `README.ko.md` with Korean headings and translated comments.

## Test plan
- [x] Links to `starter-series/create-starter` resolve
- [x] Default project name `my-service` matches spec
- [x] Template ID `docker-deploy` matches spec
- [x] Start command is `docker compose up`
- [x] `README.ko.md` mirrors EN structurally with Korean headings