### PR TITLE
feat: digest-pin Node 22, harden compose, attest provenance + SBOM

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -11,8 +11,10 @@ concurrency:
   cancel-in-progress: false
 
 permissions:
-  contents: write
-  packages: write
+  contents: write       # Create the GitHub Release
+  packages: write       # Push to GHCR
+  id-token: write       # OIDC for actions/attest-build-provenance
+  attestations: write   # Persist the build provenance attestation
 
 jobs:
   ci:
@@ -70,6 +72,7 @@ jobs:
         uses: docker/setup-buildx-action@v4
 
       - name: Build and push
+        id: build
         uses: docker/build-push-action@v7
         with:
           context: .
@@ -79,6 +82,23 @@ jobs:
             ghcr.io/${{ github.repository }}:${{ steps.version.outputs.version }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+          provenance: true
+          sbom: true
+
+      - name: Generate SBOM (CycloneDX)
+        uses: anchore/sbom-action@v0
+        with:
+          image: ghcr.io/${{ github.repository }}@${{ steps.build.outputs.digest }}
+          format: cyclonedx-json
+          output-file: sbom.cdx.json
+          upload-artifact: true
+
+      - name: Attest build provenance
+        uses: actions/attest-build-provenance@v3
+        with:
+          subject-name: ghcr.io/${{ github.repository }}
+          subject-digest: ${{ steps.build.outputs.digest }}
+          push-to-registry: true
 
       - name: Preflight — verify ~/.env.app on VPS
         uses: appleboy/ssh-action@v1
@@ -117,7 +137,10 @@ jobs:
       - name: Deploy to VPS via SSH
         uses: appleboy/ssh-action@v1
         env:
-          IMAGE: ghcr.io/${{ github.repository }}:${{ steps.version.outputs.version }}
+          # Pin by digest, not tag — guarantees the VPS pulls exactly what we just
+          # built. A tag-based deploy can race a second concurrent build that
+          # rewrites :latest / :<version> mid-rollout.
+          IMAGE: ghcr.io/${{ github.repository }}@${{ steps.build.outputs.digest }}
           PORT: ${{ secrets.APP_PORT || '3000' }}
         with:
           host: ${{ secrets.VPS_HOST }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,17 @@
 # Example: Node.js application
 # Replace with your own Dockerfile for other languages
 # See docs/DOCKERFILE_EXAMPLES.md for Python, Go, and more
+#
+# Pinned to a digest for reproducibility. Dependabot's docker ecosystem
+# refreshes this on a schedule. Node 20 reached EOL on 2026-04-30, so
+# this targets Node 22 (active LTS through 2027-04).
 
-FROM node:20-alpine
+FROM node:22-alpine@sha256:cb15fca92530d7ac113467696cf1001208dac49c3c64355fd1348c11a88ddf8f
 
 WORKDIR /app
 COPY --chown=node:node app/ .
 
+# Run as the non-root `node` user that ships with the official image.
 USER node
 
 EXPOSE 3000

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,15 @@ services:
       # Uncomment for apps with dependencies (node_modules, vendor, venv, etc.):
       # - /app/node_modules
     restart: unless-stopped
+    # Hardening defaults — override per workload if your app actually needs the
+    # capability (e.g. binding to ports <1024 → keep `cap_add: [NET_BIND_SERVICE]`).
+    read_only: true
+    tmpfs:
+      - /tmp
+    cap_drop:
+      - ALL
+    security_opt:
+      - no-new-privileges:true
     healthcheck:
       test: ["CMD-SHELL", "wget -qO /dev/null http://localhost:${PORT:-3000}/health || exit 1"]
       interval: 10s


### PR DESCRIPTION
From the 2026-05-01 audit:

## Changes
- **Dockerfile**: `node:20-alpine` (EOL 2026-04-30) → `node:22-alpine@sha256:cb15fca…`
- **docker-compose.yml**: `read_only`, `/tmp` tmpfs, `cap_drop: [ALL]`, `security_opt: no-new-privileges`. Comments explain when to relax.
- **cd.yml**:
  - `docker/build-push-action` now emits `provenance: true` + `sbom: true`
  - `anchore/sbom-action` exports CycloneDX JSON as artifact
  - `actions/attest-build-provenance@v3` signs digest, pushes attestation to GHCR
  - VPS deploy `IMAGE` switches from `:tag` to `@sha256:digest`
  - `permissions:` + `id-token: write`, `attestations: write`

## Test plan
- [ ] CI green
- [ ] Confirm GHCR shows attestation under image tag
- [ ] `docker pull `+`docker run` against the deployed digest