### PR TITLE
chore(ci): SC2086 — quote $GITHUB_OUTPUT / $GITHUB_ENV

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -33,9 +33,9 @@ jobs:
         id: version
         run: |
           if [[ "${GITHUB_REF}" == refs/tags/v* ]]; then
-            echo "version=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
+            echo "version=${GITHUB_REF#refs/tags/v}" >> "$GITHUB_OUTPUT"
           else
-            echo "version=$(cat VERSION)" >> $GITHUB_OUTPUT
+            echo "version=$(cat VERSION)" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Check tag does not exist

--- a/.github/workflows/setup.yml
+++ b/.github/workflows/setup.yml
@@ -18,9 +18,9 @@ jobs:
         run: |
           VERSION=$(cat VERSION)
           if [ "$VERSION" = "1.0.0" ] && [ -f "app/server.js" ]; then
-            echo "is_template=true" >> $GITHUB_OUTPUT
+            echo "is_template=true" >> "$GITHUB_OUTPUT"
           else
-            echo "is_template=false" >> $GITHUB_OUTPUT
+            echo "is_template=false" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Create setup checklist


### PR DESCRIPTION
actionlint sweep. shellcheck SC2086 wants the quoted form. Stylistic only — GitHub always sets these to safe paths.