### PR TITLE
chore: P0 supply-chain + UX hardening sweep (2026-05-07 audit)

### DIFF
--- a/scripts/deploy-with-rollback.sh
+++ b/scripts/deploy-with-rollback.sh
@@ -89,9 +89,17 @@ if [ -n "$PREV_IMAGE" ] && [ "$PREV_IMAGE" != "$IMAGE" ]; then
   if docker compose up -d --wait; then
     echo "Rollback succeeded."
   else
-    echo "::error::Rollback also failed — manual intervention required."
+    # Rollback failed too — remove the broken compose file so the next
+    # deploy starts from a clean slate (PREV_IMAGE detection on a broken
+    # container otherwise loops the cascade). Save a copy for forensics.
+    echo "::error::Rollback also failed — clearing compose file. Saved as docker-compose.failed.yml for investigation."
+    mv docker-compose.yml docker-compose.failed.yml 2>/dev/null || true
+    docker compose down --remove-orphans >/dev/null 2>&1 || true
   fi
 else
   echo "No previous image available to roll back to."
+  # First deploy of a bad image — same cleanup so we don't carry the
+  # broken compose into the next attempt.
+  mv docker-compose.yml docker-compose.failed.yml 2>/dev/null || true
 fi
 exit 1


### PR DESCRIPTION
Combines P0 fixes from the 2026-05-07 audit. Contents vary per repo (see file diffs):

**Cross-repo (Node)**
- Every `npm ci` → `npm ci --ignore-scripts` (Shai-Hulud / PackageGate primary infection vector — lifecycle scripts are the most exploited path)
- Lockfile sync where `engines.node` was stale at `>=20`

**Per-repo bug fixes (where applicable)**
- discord-bot: `safeRespond` deferred → `editReply` (was incorrectly using `followUp`, leaving ghost 'Bot is thinking…' messages)
- telegram-bot: `safeReply` non-Grammy errors swallowed (was rethrowing, contradicting the file's contract)
- electron: `autoUpdater` errors forwarded to renderer + 3-fail cache purge
- vscode-extension: `vsix` glob safety (fail explicitly if 0 or >1 matches)
- vscode-extension: CHANGELOG placeholder `[0.1.0] - YYYY-MM-DD` removed (now matches sibling scaffolds)
- cloudflare-pages: KV NaN recovery now logs + sets `X-Counter-Recovered` header
- docker-deploy: rollback-failure cleanup (move broken compose to .failed.yml)
- react-native: auth-context `exp`/`iss` validation on rehydrate
- discord/telegram: Railway CLI version-pinned to `@4.6.3` (was unpinned global `latest`)
- discord/telegram: `npm test` adds `--coverage` so the existing `coverageThreshold` is no longer inert

**Sources**
- [CISA — npm ecosystem compromise](https://www.cisa.gov/news-events/alerts/2025/09/23/widespread-supply-chain-compromise-impacting-npm-ecosystem)
- [Microsoft — Shai-Hulud 2.0](https://www.microsoft.com/en-us/security/blog/2025/12/09/shai-hulud-2-0-guidance-for-detecting-investigating-and-defending-against-the-supply-chain-attack/)

## Test plan
- [ ] CI green
- [ ] Local `npm ci --ignore-scripts` succeeds in fresh clone (no native modules required for this template)