### PR TITLE
[codex] Fix Caddy apt repository URLs

### DIFF
--- a/docs/HTTPS_SETUP.md
+++ b/docs/HTTPS_SETUP.md
@@ -14,8 +14,8 @@ Set up automatic HTTPS on your VPS with Caddy reverse proxy.
 ```bash
 # Ubuntu/Debian
 sudo apt install -y debian-keyring debian-archive-keyring apt-transport-https curl
-curl -1sLf 'https://dl.cloudflare.com/caddy/stable/gpg.key' | sudo gpg --dearmor -o /usr/share/keyrings/caddy-stable-archive-keyring.gpg
-curl -1sLf 'https://dl.cloudflare.com/caddy/stable/debian.deb.txt' | sudo tee /etc/apt/sources.list.d/caddy-stable.list
+curl -1sLf 'https://dl.cloudsmith.io/public/caddy/stable/gpg.key' | sudo gpg --dearmor -o /usr/share/keyrings/caddy-stable-archive-keyring.gpg
+curl -1sLf 'https://dl.cloudsmith.io/public/caddy/stable/debian.deb.txt' | sudo tee /etc/apt/sources.list.d/caddy-stable.list
 sudo apt update
 sudo apt install caddy
 ```


### PR DESCRIPTION
## What changed
- Replaces the stale Caddy APT repository host with the official Cloudsmith URLs used by Caddy packages.

## Verification
- `git diff --check`
- `npm test`
