### PR TITLE
[codex] Harden rollback deploy compose

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -69,6 +69,7 @@ docker compose up
 │   └── package.json
 ├── Dockerfile                  # 예시 빌드 (언어별 교체)
 ├── docker-compose.yml          # 로컬 개발용
+├── .env.example                # 로컬/프로덕션 환경변수 템플릿
 ├── .github/
 │   ├── workflows/
 │   │   ├── ci.yml              # 린트, compose 검증, 빌드 테스트, JS 테스트
@@ -85,6 +86,7 @@ docker compose up
 │   └── deploy-with-rollback.sh # 헬스체크 배포 + 자동 롤백
 ├── tests/                      # node:test 스위트 + 롤백 통합 테스트
 ├── package.json                # `npm test` 러너
+├── package-lock.json           # npm audit/재현성 lockfile
 └── VERSION                     # 현재 버전
 ```
 
@@ -143,6 +145,7 @@ docker compose up
 | Dockerfile 린트 | [Hadolint](https://github.com/hadolint/hadolint)로 베스트 프랙티스 검사 |
 | Compose 검증 | `docker-compose.yml` 문법 확인 |
 | 빌드 테스트 | Docker 이미지 빌드로 오류 사전 감지 |
+| 이미지 스캔 | [Trivy](https://github.com/aquasecurity/trivy)로 CRITICAL CVE 검사 |
 
 ### 보안 & 유지보수
 

--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ docker compose up
 │   └── package.json
 ├── Dockerfile                  # Example build (swap for your language)
 ├── docker-compose.yml          # Local development
+├── .env.example                # Local/prod env template
 ├── .github/
 │   ├── workflows/
 │   │   ├── ci.yml              # Lint, compose validate, build test, JS tests
@@ -85,6 +86,7 @@ docker compose up
 │   └── deploy-with-rollback.sh # Health-checked deploy + auto rollback
 ├── tests/                      # node:test suites + rollback integration test
 ├── package.json                # `npm test` runner
+├── package-lock.json           # npm audit/reproducibility lockfile
 └── VERSION                     # Current version
 ```
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,12 @@
+{
+  "name": "docker-deploy-starter",
+  "version": "0.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "docker-deploy-starter",
+      "version": "0.0.0"
+    }
+  }
+}

--- a/scripts/deploy-with-rollback.sh
+++ b/scripts/deploy-with-rollback.sh
@@ -33,6 +33,15 @@ set -euo pipefail
 ENV_FILE="${ENV_FILE:-}"
 SKIP_PULL="${SKIP_PULL:-0}"
 
+if docker compose version >/dev/null 2>&1; then
+  COMPOSE=(docker compose)
+elif docker-compose version >/dev/null 2>&1; then
+  COMPOSE=(docker-compose)
+else
+  echo "::error::Docker Compose is required (docker compose or docker-compose)." >&2
+  exit 1
+fi
+
 mkdir -p "$DEPLOY_DIR"
 cd "$DEPLOY_DIR"
 
@@ -50,6 +59,13 @@ write_compose() {
     echo "    ports:"
     echo "      - \"${PORT}:${PORT}\""
     echo "    restart: unless-stopped"
+    echo "    read_only: true"
+    echo "    tmpfs:"
+    echo "      - /tmp"
+    echo "    cap_drop:"
+    echo "      - ALL"
+    echo "    security_opt:"
+    echo "      - no-new-privileges:true"
     echo "    healthcheck:"
     echo "      test: [\"CMD-SHELL\", \"wget -qO /dev/null http://localhost:${PORT}/health || exit 1\"]"
     echo "      interval: 5s"
@@ -61,8 +77,8 @@ write_compose() {
 
 # Capture currently running image for potential rollback.
 PREV_IMAGE=""
-if docker compose ps -q app >/dev/null 2>&1; then
-  CID="$(docker compose ps -q app || true)"
+if "${COMPOSE[@]}" ps -q app >/dev/null 2>&1; then
+  CID="$("${COMPOSE[@]}" ps -q app || true)"
   if [ -n "$CID" ]; then
     PREV_IMAGE="$(docker inspect --format '{{.Config.Image}}' "$CID" 2>/dev/null || true)"
   fi
@@ -73,10 +89,10 @@ echo "Target image:   ${IMAGE}"
 write_compose "$IMAGE"
 
 if [ "$SKIP_PULL" != "1" ]; then
-  docker compose pull
+  "${COMPOSE[@]}" pull
 fi
 
-if docker compose up -d --wait; then
+if "${COMPOSE[@]}" up -d --wait; then
   echo "Deploy succeeded."
   docker image prune -f >/dev/null 2>&1 || true
   exit 0
@@ -86,7 +102,7 @@ echo "::error::Deploy health check failed."
 if [ -n "$PREV_IMAGE" ] && [ "$PREV_IMAGE" != "$IMAGE" ]; then
   echo "Rolling back to $PREV_IMAGE"
   write_compose "$PREV_IMAGE"
-  if docker compose up -d --wait; then
+  if "${COMPOSE[@]}" up -d --wait; then
     echo "Rollback succeeded."
   else
     # Rollback failed too — tear the broken container down BEFORE moving the
@@ -96,7 +112,7 @@ if [ -n "$PREV_IMAGE" ] && [ "$PREV_IMAGE" != "$IMAGE" ]; then
     # detection on a broken container otherwise loops the cascade). Save a
     # copy for forensics.
     echo "::error::Rollback also failed — clearing compose file. Saved as docker-compose.failed.yml for investigation."
-    docker compose down --remove-orphans >/dev/null 2>&1 || true
+    "${COMPOSE[@]}" down --remove-orphans >/dev/null 2>&1 || true
     mv docker-compose.yml docker-compose.failed.yml 2>/dev/null || true
   fi
 else
@@ -105,7 +121,7 @@ else
   # moving the compose file, so `docker compose down` can find it) so we
   # don't leak an unhealthy container, then move the broken compose aside so
   # we don't carry it into the next attempt.
-  docker compose down --remove-orphans >/dev/null 2>&1 || true
+  "${COMPOSE[@]}" down --remove-orphans >/dev/null 2>&1 || true
   mv docker-compose.yml docker-compose.failed.yml 2>/dev/null || true
 fi
 exit 1

--- a/tests/rollback-integration.sh
+++ b/tests/rollback-integration.sh
@@ -32,12 +32,20 @@ WORK_DIR="$(mktemp -d)"
 pass() { echo "PASS: $1"; }
 fail() { echo "FAIL: $1" >&2; exit 1; }
 
+if docker compose version >/dev/null 2>&1; then
+  COMPOSE=(docker compose)
+elif docker-compose version >/dev/null 2>&1; then
+  COMPOSE=(docker-compose)
+else
+  fail "Docker Compose is required (docker compose or docker-compose)"
+fi
+
 cleanup() {
   if [ -f "$WORK_DIR/docker-compose.yml" ]; then
-    (cd "$WORK_DIR" && docker compose down -v --remove-orphans >/dev/null 2>&1 || true)
+    (cd "$WORK_DIR" && "${COMPOSE[@]}" down -v --remove-orphans >/dev/null 2>&1 || true)
   fi
   if [ -f "$WORK_DIR/docker-compose.failed.yml" ]; then
-    (cd "$WORK_DIR" && docker compose -f docker-compose.failed.yml down -v --remove-orphans >/dev/null 2>&1 || true)
+    (cd "$WORK_DIR" && "${COMPOSE[@]}" -f docker-compose.failed.yml down -v --remove-orphans >/dev/null 2>&1 || true)
   fi
   rm -rf "$WORK_DIR"
   docker rmi -f "$GOOD_IMAGE" "$BAD_IMAGE" "rollback-test/bad:prev" >/dev/null 2>&1 || true
@@ -63,14 +71,27 @@ check_health() {
 running_app_containers() {
   local count=0 ids
   if [ -f "$WORK_DIR/docker-compose.yml" ]; then
-    ids="$(cd "$WORK_DIR" && docker compose ps -q app 2>/dev/null || true)"
+    ids="$(cd "$WORK_DIR" && "${COMPOSE[@]}" ps -q app 2>/dev/null || true)"
     [ -n "$ids" ] && count=$((count + $(echo "$ids" | grep -c .)))
   fi
   if [ -f "$WORK_DIR/docker-compose.failed.yml" ]; then
-    ids="$(cd "$WORK_DIR" && docker compose -f docker-compose.failed.yml ps -q app 2>/dev/null || true)"
+    ids="$(cd "$WORK_DIR" && "${COMPOSE[@]}" -f docker-compose.failed.yml ps -q app 2>/dev/null || true)"
     [ -n "$ids" ] && count=$((count + $(echo "$ids" | grep -c .)))
   fi
   echo "$count"
+}
+
+assert_compose_hardened() {
+  local label="$1"
+  grep -q '^    read_only: true$' "$WORK_DIR/docker-compose.yml" \
+    || fail "$label: compose missing read_only hardening"
+  grep -q '^      - /tmp$' "$WORK_DIR/docker-compose.yml" \
+    || fail "$label: compose missing tmpfs /tmp"
+  grep -q '^      - ALL$' "$WORK_DIR/docker-compose.yml" \
+    || fail "$label: compose missing cap_drop ALL"
+  grep -q '^      - no-new-privileges:true$' "$WORK_DIR/docker-compose.yml" \
+    || fail "$label: compose missing no-new-privileges"
+  pass "$label: compose includes hardening defaults"
 }
 
 # Assert the deployment is fully quiesced after a terminal failure:
@@ -110,6 +131,7 @@ else
 fi
 check_health good || fail "good image not serving /health"
 pass "good image /health responds with build=good"
+assert_compose_hardened "scenario 1"
 
 # ---------------------------------------------------------------------------
 # Scenario 2: deploying the bad image on top must fail AND rollback must
@@ -136,9 +158,10 @@ if grep -q "image: $GOOD_IMAGE" "$WORK_DIR/docker-compose.yml"; then
 else
   fail "compose file does not point to good image after rollback"
 fi
+assert_compose_hardened "scenario 2"
 
 # Tear down before scenario 3 (we want a truly fresh state with no PREV_IMAGE).
-(cd "$WORK_DIR" && docker compose down -v --remove-orphans >/dev/null 2>&1 || true)
+(cd "$WORK_DIR" && "${COMPOSE[@]}" down -v --remove-orphans >/dev/null 2>&1 || true)
 rm -f "$WORK_DIR/docker-compose.yml"
 
 # ---------------------------------------------------------------------------
@@ -161,9 +184,9 @@ pass "bad image first deploy returned non-zero ($rc)"
 assert_quiesced "scenario 3"
 
 # Fresh state before scenario 4.
-(cd "$WORK_DIR" && docker compose down -v --remove-orphans >/dev/null 2>&1 || true)
+(cd "$WORK_DIR" && "${COMPOSE[@]}" down -v --remove-orphans >/dev/null 2>&1 || true)
 if [ -f "$WORK_DIR/docker-compose.failed.yml" ]; then
-  (cd "$WORK_DIR" && docker compose -f docker-compose.failed.yml down -v --remove-orphans >/dev/null 2>&1 || true)
+  (cd "$WORK_DIR" && "${COMPOSE[@]}" -f docker-compose.failed.yml down -v --remove-orphans >/dev/null 2>&1 || true)
 fi
 rm -f "$WORK_DIR/docker-compose.yml" "$WORK_DIR/docker-compose.failed.yml"
 
@@ -198,7 +221,7 @@ services:
       retries: 3
       start_period: 5s
 EOF
-(cd "$WORK_DIR" && docker compose up -d >/dev/null 2>&1)
+(cd "$WORK_DIR" && "${COMPOSE[@]}" up -d >/dev/null 2>&1)
 # Sanity: a previous container is actually running before we attempt the deploy.
 prev_running="$(running_app_containers)"
 [ "$prev_running" -ge 1 ] || fail "scenario 4 setup: previous unhealthy container is not running"


### PR DESCRIPTION
## Summary

- add Docker Compose CLI fallback for rollback deploys (`docker compose` or `docker-compose`)
- carry local compose hardening defaults into the VPS rollback compose (`read_only`, `/tmp` tmpfs, dropped caps, no-new-privileges)
- assert those hardening defaults in the rollback integration test
- add a package lock so `npm audit --audit-level=high` is reproducible
- align README file trees and Korean CI table with repo reality

## Validation

- `bash -n scripts/deploy-with-rollback.sh tests/rollback-integration.sh`
- `npm test`
- `npm audit --audit-level=high`
- `npm pack --dry-run --json`
- `cp .env.example .env && docker-compose config >/tmp/docker-deploy-starter-compose-config.yml`
- `docker build -t docker-deploy-starter:test .`
- `bash tests/rollback-integration.sh`
- `git diff --check`

## Notes

Local Docker has the standalone `docker-compose` CLI but not the `docker compose` plugin, which exposed the rollback script portability gap.
