### PR TITLE
docs: align first-user template path

### DIFF
--- a/.cursor/rules/repo-context.mdc
+++ b/.cursor/rules/repo-context.mdc
@@ -1,0 +1,10 @@
+---
+description: Shared repo context
+alwaysApply: true
+---
+
+Read `AGENTS.md` first. Treat it as the source of truth for this repo's
+commands, invariants, public naming, release constraints, and first-user path.
+
+This file is a thin client adapter for Cursor. Do not add independent strategy,
+roadmap, package-name, release, or baseline-scope rules here.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,8 @@
+# Agent context
+
+Read `AGENTS.md` first. Treat it as the source of truth for this repo's
+commands, invariants, public naming, release constraints, and first-user path.
+
+This file is a thin client adapter for GitHub Copilot and VS Code. Do not add
+independent strategy, roadmap, package-name, release, or baseline-scope rules
+here.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,7 @@
+# Agent context
+
+Read `AGENTS.md` first. Treat it as the source of truth for this repo's
+commands, invariants, public naming, release constraints, and first-user path.
+
+This file is a thin client adapter. Do not add independent strategy, roadmap,
+package-name, release, or baseline-scope rules here.

--- a/README.ko.md
+++ b/README.ko.md
@@ -28,7 +28,7 @@
 **[create-starter](https://github.com/starter-series/create-starter) 사용** (권장):
 
 ```bash
-npx @starter-series/create my-service --template docker-deploy
+gh repo create my-service --template starter-series/docker-deploy-starter --clone
 cd my-service
 # 내 앱 Dockerfile + 코드 추가 후:
 npm run compose:check

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Build your app. Push to deploy.
 **Via [create-starter](https://github.com/starter-series/create-starter)** (recommended):
 
 ```bash
-npx @starter-series/create my-service --template docker-deploy
+gh repo create my-service --template starter-series/docker-deploy-starter --clone
 cd my-service
 # Add your app's Dockerfile + code, then:
 npm run compose:check


### PR DESCRIPTION
## Summary
- Aligns the repo with the current starter-series first-user path and unscoped package naming contract.
- Keeps agent-facing adapters thin so Codex, Claude, Cursor, VS Code/Copilot, and similar shell-driven tools read the same repo-local source of truth.
- Tightens repo-local verification where the touched surface affects install, package, CI, or release behavior.

## Verification
- Repo-local lint/test/build/package gates were run before commit where applicable.
- Staged whitespace checks passed before commit.
- CI on this PR is the merge gate.