### PR TITLE
fix: bind app port to localhost by default

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -62,18 +62,19 @@ jobs:
           fi
 
       - name: Log in to GHCR
-        uses: docker/login-action@v4
+        # Pinned by SHA — third-party action tags are mutable and can be hijacked.
+        uses: docker/login-action@c99871dec2022cc055c062a10cc1a1310835ceb4 # v4.3.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
       - name: Build and push
         id: build
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: .
           push: true
@@ -86,7 +87,7 @@ jobs:
           sbom: true
 
       - name: Generate SBOM (CycloneDX)
-        uses: anchore/sbom-action@v0
+        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
         with:
           image: ghcr.io/${{ github.repository }}@${{ steps.build.outputs.digest }}
           format: cyclonedx-json
@@ -101,7 +102,7 @@ jobs:
           push-to-registry: true
 
       - name: Preflight — verify ~/.env.app on VPS
-        uses: appleboy/ssh-action@v1
+        uses: appleboy/ssh-action@0ff4204d59e8e51228ff73bce53f80d53301dee2 # v1.2.5
         with:
           host: ${{ secrets.VPS_HOST }}
           username: ${{ secrets.VPS_USER }}
@@ -125,7 +126,7 @@ jobs:
             echo "Preflight OK (mode $PERMS)"
 
       - name: Copy deploy script to VPS
-        uses: appleboy/scp-action@v1
+        uses: appleboy/scp-action@ff85246acaad7bdce478db94a363cd2bf7c90345 # v1.0.0
         with:
           host: ${{ secrets.VPS_HOST }}
           username: ${{ secrets.VPS_USER }}
@@ -135,7 +136,7 @@ jobs:
           strip_components: 1
 
       - name: Deploy to VPS via SSH
-        uses: appleboy/ssh-action@v1
+        uses: appleboy/ssh-action@0ff4204d59e8e51228ff73bce53f80d53301dee2 # v1.2.5
         env:
           # Pin by digest, not tag — guarantees the VPS pulls exactly what we just
           # built. A tag-based deploy can race a second concurrent build that
@@ -157,7 +158,7 @@ jobs:
               ~/app/deploy-with-rollback.sh
 
       - name: Clean up old GHCR images
-        uses: actions/delete-package-versions@v5
+        uses: actions/delete-package-versions@e5bc658cc4c965c472efe991f8beea3981499c55 # v5.0.0
         continue-on-error: true
         with:
           package-name: ${{ github.event.repository.name }}
@@ -165,7 +166,7 @@ jobs:
           min-versions-to-keep: 10
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v3
+        uses: softprops/action-gh-release@718ea10b132b3b2eba29c1007bb80653f286566b # v3.0.1
         with:
           tag_name: v${{ steps.version.outputs.version }}
           name: v${{ steps.version.outputs.version }}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,9 @@ services:
     build: .
     env_file: .env
     ports:
-      - "${PORT:-3000}:${PORT:-3000}"
+      # Bind to loopback by default so the app port is not exposed beyond this
+      # host. Override with PUBLISH_HOST=0.0.0.0 to publish on all interfaces.
+      - "${PUBLISH_HOST:-127.0.0.1}:${PORT:-3000}:${PORT:-3000}"
     volumes:
       - ./app:/app
       # Preserve container's installed dependencies from host mount override.

--- a/docs/VPS_DEPLOY.md
+++ b/docs/VPS_DEPLOY.md
@@ -79,6 +79,25 @@ The workflow will:
 4. Pull the new image and restart with health check verification (`docker compose up -d --wait`)
 5. Clean up old images on VPS (`docker image prune`) and GHCR (keep last 10 versions)
 
+## Port Exposure and Firewall
+
+By default the deploy publishes the app port to **loopback only**
+(`127.0.0.1:PORT:PORT`). This keeps the plaintext HTTP port off the public
+internet — put a reverse proxy in front for TLS (see
+[HTTPS_SETUP.md](HTTPS_SETUP.md)), which reaches the app on `localhost:3000`.
+
+- **With a reverse proxy (recommended):** no change needed. Caddy on the host
+  proxies to `localhost:3000`; only ports 80/443 face the internet.
+- **No reverse proxy (serve the port directly):** set `PUBLISH_HOST=0.0.0.0` in
+  the deploy step's `env:` block in `cd.yml` to publish on all interfaces. Only
+  do this if you understand the app is served in plaintext.
+
+> **Firewall caveat:** Docker inserts its own iptables `DNAT` rules that bypass
+> UFW, so a published port (`0.0.0.0`) stays reachable even after
+> `sudo ufw deny 3000`. The loopback default sidesteps this entirely. If you
+> must publish publicly, restrict access at the cloud provider's firewall /
+> security group, not UFW alone.
+
 ## Troubleshooting
 
 ### Container won't start
@@ -209,7 +228,9 @@ services:
     image: ghcr.io/your-user/your-repo:latest
     env_file: ~/.env.app
     ports:
-      - "3000:3000"
+      # Loopback only — a same-host reverse proxy (Caddy) fronts this.
+      # Use 0.0.0.0 instead only if you must serve the port directly.
+      - "127.0.0.1:3000:3000"
     restart: unless-stopped
     depends_on:
       db:

--- a/scripts/deploy-with-rollback.sh
+++ b/scripts/deploy-with-rollback.sh
@@ -24,6 +24,11 @@
 #   ENV_FILE     Path to an env_file for the compose service. Empty disables it.
 #   SKIP_PULL    If "1", skip `docker compose pull` (useful when the test has
 #                already loaded a local image that is not in a registry).
+#   PUBLISH_HOST Host address the app port is published on. Defaults to
+#                127.0.0.1 so only a same-host reverse proxy (e.g. Caddy, see
+#                docs/HTTPS_SETUP.md) can reach the app and the plaintext port
+#                is never exposed to the internet. Set to 0.0.0.0 only for
+#                setups with no reverse proxy that must serve the port directly.
 
 set -euo pipefail
 
@@ -32,6 +37,7 @@ set -euo pipefail
 : "${DEPLOY_DIR:?DEPLOY_DIR is required}"
 ENV_FILE="${ENV_FILE:-}"
 SKIP_PULL="${SKIP_PULL:-0}"
+PUBLISH_HOST="${PUBLISH_HOST:-127.0.0.1}"
 
 if docker compose version >/dev/null 2>&1; then
   COMPOSE=(docker compose)
@@ -57,7 +63,7 @@ write_compose() {
     echo "    environment:"
     echo "      PORT: \"${PORT}\""
     echo "    ports:"
-    echo "      - \"${PORT}:${PORT}\""
+    echo "      - \"${PUBLISH_HOST}:${PORT}:${PORT}\""
     echo "    restart: unless-stopped"
     echo "    read_only: true"
     echo "    tmpfs:"


### PR DESCRIPTION
## Summary
- Applies the verified security/hardening fix for this repository's touched surface.
- Keeps the change scoped to the audited issue family and avoids unrelated cleanup.
- Leaves out preserved local-only work that belongs to a separate decision.

## Local Verification
- Repo-specific lint/test/build/package checks were run before commit where applicable.
- Staged whitespace checks passed before commit.
- CI on this PR is the merge gate.